### PR TITLE
Specify Configuration File on Command Line

### DIFF
--- a/py-hole-bind9RPZ
+++ b/py-hole-bind9RPZ
@@ -28,14 +28,18 @@ import os
 import requests
 import sys
 import subprocess
+import argparse
 
 
 
 
-
+# read command line arguments with argparse
+parser = argparse.ArgumentParser(description='A Pi-hole inspired DNS firewall for use with bind/named using RPZ')
+parser.add_argument('-c', '--config', type=str, help='Configuration file to use', default='/etc/bind/py-hole-bind9RPZ_config.yaml')
+args = parser.parse_args()
 
 # read config
-configfile = '/etc/bind/py-hole-bind9RPZ_config.yaml'
+configfile = args.config
 config = {
     # base config overridden by configfile
     'cachedir': '/var/local/bindRPZ',

--- a/py-hole-bind9RPZ
+++ b/py-hole-bind9RPZ
@@ -35,7 +35,7 @@ import argparse
 
 # read command line arguments with argparse
 parser = argparse.ArgumentParser(description='A Pi-hole inspired DNS firewall for use with bind/named using RPZ')
-parser.add_argument('-c', '--config', type=str, help='Configuration file to use (default: /etc/py-hole-bind9RPZ_config.yaml)', default='/etc/bind/py-hole-bind9RPZ_config.yaml')
+parser.add_argument('-c', '--config', type=str, help='Configuration file to use (default: /etc/bind/py-hole-bind9RPZ_config.yaml)', default='/etc/bind/py-hole-bind9RPZ_config.yaml')
 args = parser.parse_args()
 
 # read config

--- a/py-hole-bind9RPZ
+++ b/py-hole-bind9RPZ
@@ -35,7 +35,7 @@ import argparse
 
 # read command line arguments with argparse
 parser = argparse.ArgumentParser(description='A Pi-hole inspired DNS firewall for use with bind/named using RPZ')
-parser.add_argument('-c', '--config', type=str, help='Configuration file to use', default='/etc/bind/py-hole-bind9RPZ_config.yaml')
+parser.add_argument('-c', '--config', type=str, help='Configuration file to use (default: /etc/py-hole-bind9RPZ_config.yaml)', default='/etc/bind/py-hole-bind9RPZ_config.yaml')
 args = parser.parse_args()
 
 # read config

--- a/py-hole-dnsmasq
+++ b/py-hole-dnsmasq
@@ -30,14 +30,20 @@ import os
 import requests
 import sys
 import subprocess
+import argparse
 
 
 
 
 
+
+# read command line arguments with argparse
+parser = argparse.ArgumentParser(description='A Pi-hole inspired DNS firewall for use on laptops running NetworkManager with dnsmasq')
+parser.add_argument('-c', '--config', type=str, help='Configuration file to use', default='/etc/py-hole-dnsmasq_config.yaml')
+args = parser.parse_args()
 
 # read config
-configfile = '/etc/py-hole-dnsmasq_config.yaml'
+configfile = args.config
 config = {
     # base config overridden by configfile
     'cachedir': '/var/local/py-hole',

--- a/py-hole-dnsmasq
+++ b/py-hole-dnsmasq
@@ -39,7 +39,7 @@ import argparse
 
 # read command line arguments with argparse
 parser = argparse.ArgumentParser(description='A Pi-hole inspired DNS firewall for use on laptops running NetworkManager with dnsmasq')
-parser.add_argument('-c', '--config', type=str, help='Configuration file to use', default='/etc/py-hole-dnsmasq_config.yaml')
+parser.add_argument('-c', '--config', type=str, help='Configuration file to use (default: /etc/py-hole-dnsmasq_config.yaml)', default='/etc/py-hole-dnsmasq_config.yaml')
 args = parser.parse_args()
 
 # read config


### PR DESCRIPTION
This allows the specification of the path to the configuration file on the command line.
Uses argparse for argument parsing and usage message display.
Defaults to `/etc/bind/<script name>_config.yaml` for bind9RPZ and `/etc/<script name>_config.yaml` for dnsmasq.